### PR TITLE
Added 'layout' keyword. Fixed 'texture2DProj' function.

### DIFF
--- a/GLSL.tmLanguage
+++ b/GLSL.tmLanguage
@@ -33,6 +33,12 @@
 	<array>
 		<dict>
 			<key>match</key>
+			<string>^\s*#\s*(define|undef|if|ifdef|ifndef|else|elif|endif|error|pragma|extension|version|line)\b</string>
+			<key>name</key>
+			<string>keyword.control.glsl</string>
+		</dict>
+		<dict>
+			<key>match</key>
 			<string>\b(break|case|continue|default|discard|do|else|for|if|return|switch|while)\b</string>
 			<key>name</key>
 			<string>keyword.control.glsl</string>


### PR DESCRIPTION
'layout' keyword restores other keywords highlight in constructions like 'layout (location = 0) in vec3 position'. Previously it was considered as function.
texture2DProj contained some unprinted symbol that was preventing it to be recognized.
