### PR TITLE
Remove redundant "DOCTYPE" and "uuid" keys in tmPreferences file

### DIFF
--- a/esslComments.tmPreferences
+++ b/esslComments.tmPreferences
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
   <key>name</key>
@@ -30,7 +29,5 @@
       </dict>
     </array>
   </dict>
-  <key>uuid</key>
-  <string>21612447-B2BA-43DE-8984-66D799A546C0</string>
 </dict>
 </plist>

--- a/glslComments.tmPreferences
+++ b/glslComments.tmPreferences
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
   <key>name</key>
@@ -30,7 +29,5 @@
       </dict>
     </array>
   </dict>
-  <key>uuid</key>
-  <string>38776B54-7AA3-4A17-8841-D3BEC4B753DA</string>
 </dict>
 </plist>


### PR DESCRIPTION
The "doctype" and "uuid" are not used by sublime text, so they can be removed.