### PR TITLE
Remove DOCTYPE from tmPreferences

### DIFF
--- a/esslComments.tmPreferences
+++ b/esslComments.tmPreferences
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
   <key>name</key>

--- a/glslComments.tmPreferences
+++ b/glslComments.tmPreferences
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
   <key>name</key>


### PR DESCRIPTION
Remove DOCTYPE from tmPreferences.

Are you sure about this XML validation? [The doctype was removed from the default syntaxes](https://github.com/sublimehq/Packages/commit/61bfd68ea07a3aede68cd6a65c80be702b3d6db8).